### PR TITLE
Added divider color variants

### DIFF
--- a/branding/LICENSES.json
+++ b/branding/LICENSES.json
@@ -1,5 +1,5 @@
 {
-    "@brightlayer-ui/types@1.0.0": {
+    "@brightlayer-ui/types@2.0.0": {
         "licenses": "BSD-3-Clause",
         "repository": "https://github.com/brightlayer-ui/types",
         "licenseUrl": "https://github.com/brightlayer-ui/types/raw/master/LICENSE",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@brightlayer-ui/colors",
-    "version": "3.2.0-alpha.3",
+    "version": "3.2.0-alpha.4",
     "description": "Brightlayer UI colors for Eaton applications",
     "main": "./dist/commonjs/index.js",
     "types": "./dist/commonjs/index.d.ts",

--- a/ui/src/palette.ts
+++ b/ui/src/palette.ts
@@ -187,3 +187,7 @@ export const highlight: string = '#5590EF';
 export const highlightBlue: string = '#7BABFF';
 
 export const textFieldContainer: string = '#BDCAD1';
+
+export const lightThemeDivider: string = '#4D5C6A';
+ 
+export const darkThemeDivider: string = '#F5FAFF';

--- a/ui/src/palette.ts
+++ b/ui/src/palette.ts
@@ -189,5 +189,5 @@ export const highlightBlue: string = '#7BABFF';
 export const textFieldContainer: string = '#BDCAD1';
 
 export const lightThemeDivider: string = '#4D5C6A';
- 
+
 export const darkThemeDivider: string = '#F5FAFF';


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->

Fixes #BLUI-7278 .

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->

#### Changes proposed in this Pull Request:

- Added light and dark theme colors for divider as per figma M2.
- Added the alpha version for the usage.

<!-- Include screenshots if they will help illustrate the changes in this PR -->

#### Screenshots / Screen Recording (if applicable)

<img width="744" height="28" alt="Screenshot 2026-05-28 at 3 26 12 PM" src="https://github.com/user-attachments/assets/933e5b2c-a2b9-42dc-9fa9-75d32a813c84" />

<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->

#### To Test:

- Publish alpha version and use this color token in theme for divider and check the related components

<!-- Useful for draft pull requests -->

#### Any specific feedback you are looking for?

-

#### PR Readiness Checklist

Please confirm all items below have been addressed prior to requesting review:

- [x] Code has been formatted with Prettier
- [x] Code passes all linting checks
- [x] All tests pass
- [x] Code builds successfully
- [ ] Translations have been updated (if applicable)
- [ ] Documentation has been updated (if applicable)
- [ ] Changelog has been updated (if applicable)